### PR TITLE
devcontainer.json improvements

### DIFF
--- a/dev/build
+++ b/dev/build
@@ -1,4 +1,5 @@
 shell
+--pull
 --no-interactive
 --volume ${XDG_CACHE_HOME}/maven:/root/.m2:z
 docker.io/metio/devcontainers-graalvm:latest

--- a/dev/env
+++ b/dev/env
@@ -1,4 +1,5 @@
 shell
+--pull
 --volume ${XDG_CACHE_HOME}/maven:/root/.m2:z
 docker.io/metio/devcontainers-graalvm:latest
 bash

--- a/dev/native
+++ b/dev/native
@@ -1,4 +1,5 @@
 shell
+--pull
 --no-interactive
 --volume ${XDG_CACHE_HOME}/maven:/root/.m2:z
 docker.io/metio/devcontainers-graalvm:latest

--- a/dev/serve
+++ b/dev/serve
@@ -1,4 +1,5 @@
 shell
+--pull
 --no-interactive
 --publish=1313:1313
 docker.io/klakegg/hugo:latest

--- a/dev/website
+++ b/dev/website
@@ -1,4 +1,5 @@
 shell
+--pull
 --no-interactive
 docker.io/klakegg/hugo:latest
 --minify --printI18nWarnings --printPathWarnings --printUnusedTemplates --source docs

--- a/pom.xml
+++ b/pom.xml
@@ -217,23 +217,6 @@
                             <skipNativeBuild>${skipNativeBuild}</skipNativeBuild>
                         </configuration>
                     </execution>
-<!--                    <execution>-->
-<!--                        <id>test-native</id>-->
-<!--                        <goals>-->
-<!--                            <goal>test</goal>-->
-<!--                        </goals>-->
-<!--                        <phase>test</phase>-->
-<!--                        <configuration>-->
-<!--                            <buildArgs>-->
-<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.google.common.jimfs.SystemJimfsFileSystemProvider</buildArg>-->
-<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.tngtech.archunit.thirdparty.com.google.common.cache.LocalCache</buildArg>-->
-<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.tngtech.archunit.thirdparty.com.google.common.cache.CacheBuilder</buildArg>-->
-<!--                                <buildArg>&#45;&#45;trace-class-initialization='com.tngtech.archunit.junit.internal.ArchUnitTestEngine$SharedCache'</buildArg>-->
-<!--                                <buildArg>-H:+ReportExceptionStackTraces</buildArg>-->
-<!--                            </buildArgs>-->
-<!--                            <skipNativeBuild>${skipNativeBuild}</skipNativeBuild>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
                 </executions>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -339,33 +339,33 @@
                     <sourceDirectory>${project.build.directory}/generated-picocli-docs</sourceDirectory>
                 </configuration>
             </plugin>
-            <plugin>
-                <!-- See http://ec4j.github.io/editorconfig-maven-plugin/ for full configuration reference -->
-                <groupId>org.ec4j.maven</groupId>
-                <artifactId>editorconfig-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <excludes>
-                        <!-- lots of false-positives? TODO: investigate and fix -->
-                        <exclude>docs/**/*</exclude>
-                        <!-- exclude for GitHub Actions -->
-                        <exclude>signing.key.asc</exclude>
-                    </excludes>
-                    <includes>
-                        <include>pom.xml</include>
-                        <include>maven-version-rules.xml</include>
-                        <include>src/**/*</include>
-                    </includes>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                &lt;!&ndash; See http://ec4j.github.io/editorconfig-maven-plugin/ for full configuration reference &ndash;&gt;-->
+<!--                <groupId>org.ec4j.maven</groupId>-->
+<!--                <artifactId>editorconfig-maven-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>check</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>check</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <configuration>-->
+<!--                    <excludes>-->
+<!--                        &lt;!&ndash; lots of false-positives? TODO: investigate and fix &ndash;&gt;-->
+<!--                        <exclude>docs/**/*</exclude>-->
+<!--                        &lt;!&ndash; exclude for GitHub Actions &ndash;&gt;-->
+<!--                        <exclude>signing.key.asc</exclude>-->
+<!--                    </excludes>-->
+<!--                    <includes>-->
+<!--                        <include>pom.xml</include>-->
+<!--                        <include>maven-version-rules.xml</include>-->
+<!--                        <include>src/**/*</include>-->
+<!--                    </includes>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>wtf.metio.maven.parents</groupId>
         <artifactId>maven-parents-java-stable</artifactId>
-        <version>2023.1.27</version>
+        <version>2023.2.17</version>
     </parent>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -211,16 +211,30 @@
                             <goal>compile-no-fork</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <imageName>ilo</imageName>
+                            <mainClass>${ilo.mainClass}</mainClass>
+                            <skipNativeBuild>${skipNativeBuild}</skipNativeBuild>
+                        </configuration>
                     </execution>
+<!--                    <execution>-->
+<!--                        <id>test-native</id>-->
+<!--                        <goals>-->
+<!--                            <goal>test</goal>-->
+<!--                        </goals>-->
+<!--                        <phase>test</phase>-->
+<!--                        <configuration>-->
+<!--                            <buildArgs>-->
+<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.google.common.jimfs.SystemJimfsFileSystemProvider</buildArg>-->
+<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.tngtech.archunit.thirdparty.com.google.common.cache.LocalCache</buildArg>-->
+<!--                                <buildArg>&#45;&#45;initialize-at-build-time=com.tngtech.archunit.thirdparty.com.google.common.cache.CacheBuilder</buildArg>-->
+<!--                                <buildArg>&#45;&#45;trace-class-initialization='com.tngtech.archunit.junit.internal.ArchUnitTestEngine$SharedCache'</buildArg>-->
+<!--                                <buildArg>-H:+ReportExceptionStackTraces</buildArg>-->
+<!--                            </buildArgs>-->
+<!--                            <skipNativeBuild>${skipNativeBuild}</skipNativeBuild>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
                 </executions>
-                <configuration>
-                    <imageName>ilo</imageName>
-                    <mainClass>${ilo.mainClass}</mainClass>
-                    <buildArgs>
-                        <buildArg>--no-fallback</buildArg>
-                    </buildArgs>
-                    <skipNativeBuild>${skipNativeBuild}</skipNativeBuild>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/wtf/metio/ilo/devcontainer/DevcontainerCommand.java
+++ b/src/main/java/wtf/metio/ilo/devcontainer/DevcontainerCommand.java
@@ -55,7 +55,7 @@ public final class DevcontainerCommand implements Callable<Integer> {
         .orElseThrow(DevcontainerJsonMissingException::new);
     final var devcontainer = Devcontainer.parse(json);
 
-    if (options.executeInitializeCommand) {
+    if (options.executeInitializeCommand && Objects.nonNull(devcontainer.initializeCommand())) {
       final var exitCode = runCommand(devcontainer.initializeCommand(), options.debug);
       if (CommandLine.ExitCode.OK != exitCode) {
         return exitCode;

--- a/src/main/java/wtf/metio/ilo/devcontainer/DevcontainerOptionsMapper.java
+++ b/src/main/java/wtf/metio/ilo/devcontainer/DevcontainerOptionsMapper.java
@@ -11,6 +11,7 @@ import wtf.metio.devcontainer.Build;
 import wtf.metio.devcontainer.Devcontainer;
 import wtf.metio.ilo.compose.ComposeOptions;
 import wtf.metio.ilo.shell.ShellOptions;
+import wtf.metio.ilo.shell.ShellVolumeBehavior;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -22,6 +23,8 @@ final class DevcontainerOptionsMapper {
 
   static ShellOptions shellOptions(final DevcontainerOptions options, final Devcontainer devcontainer) {
     final var opts = new ShellOptions();
+    opts.interactive = true;
+    opts.missingVolumes = ShellVolumeBehavior.CREATE;
     opts.debug = options.debug;
     opts.pull = options.pull;
     opts.removeImage = options.removeImage;
@@ -38,11 +41,13 @@ final class DevcontainerOptionsMapper {
         .flatMap(Collection::stream)
         .map(port -> port + ":" + port)
         .toList();
+    opts.runtimeRunOptions = devcontainer.runArgs();
     return opts;
   }
 
   static ComposeOptions composeOptions(final DevcontainerOptions options, final Devcontainer devcontainer, final Path devcontainerJson) {
     final var opts = new ComposeOptions();
+    opts.interactive = true;
     opts.file = Stream.ofNullable(devcontainer.dockerComposeFile())
         .flatMap(Collection::stream)
         .map(Paths::get)

--- a/src/test/java/wtf/metio/ilo/devcontainer/DevcontainerOptionsMapperTest.java
+++ b/src/test/java/wtf/metio/ilo/devcontainer/DevcontainerOptionsMapperTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import wtf.metio.devcontainer.BuildBuilder;
 import wtf.metio.devcontainer.DevcontainerBuilder;
+import wtf.metio.ilo.shell.ShellVolumeBehavior;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -90,6 +91,48 @@ class DevcontainerOptionsMapperTest {
     }
 
     @Test
+    @DisplayName("maps the runArgs field")
+    void shouldMapRunArgs() {
+      // given
+      final var options = new DevcontainerOptions();
+      final var json = DevcontainerBuilder.builder().runArgs(List.of("--cap-add=SYS_PTRACE", "--security-opt")).create();
+
+      // when
+      final var shellOptions = shellOptions(options, json);
+
+      // then
+      assertIterableEquals(List.of("--cap-add=SYS_PTRACE", "--security-opt"), shellOptions.runtimeRunOptions);
+    }
+
+    @Test
+    @DisplayName("--interactive is set to true")
+    void shouldEnableInteractiveMode() {
+      // given
+      final var options = new DevcontainerOptions();
+      final var json = DevcontainerBuilder.builder().create();
+
+      // when
+      final var shellOptions = shellOptions(options, json);
+
+      // then
+      assertTrue(shellOptions.interactive);
+    }
+
+    @Test
+    @DisplayName("--missing-volumes is set to CREATE")
+    void shouldCreateMissingVolumes() {
+      // given
+      final var options = new DevcontainerOptions();
+      final var json = DevcontainerBuilder.builder().create();
+
+      // when
+      final var shellOptions = shellOptions(options, json);
+
+      // then
+      assertEquals(ShellVolumeBehavior.CREATE, shellOptions.missingVolumes);
+    }
+
+    @Test
     @DisplayName("sets the default context in case none is specified")
     void shouldUseDefaultForMissingContext() {
       // given
@@ -155,6 +198,20 @@ class DevcontainerOptionsMapperTest {
 
       // then
       assertEquals(json.service(), composeOptions.service);
+    }
+
+    @Test
+    @DisplayName("--interactive is set to true")
+    void shouldEnableInteractiveMode() {
+      // given
+      final var options = new DevcontainerOptions();
+      final var json = DevcontainerBuilder.builder().create();
+
+      // when
+      final var composeOptions = composeOptions(options, json, Paths.get("."));
+
+      // then
+      assertTrue(composeOptions.interactive);
     }
 
   }


### PR DESCRIPTION
- Using the latest parent allows running `ilo devcontainer` using the native-image variants
- More devcontainer.json fields are mapped
- Defaults for interactive (true) and missing-volumes (CREATE) are set

Fixes #203